### PR TITLE
Use X-KIX-Queue if set for SystemMonitoringX.pm

### DIFF
--- a/Kernel/System/PostMaster/Filter/SystemMonitoringX.pm
+++ b/Kernel/System/PostMaster/Filter/SystemMonitoringX.pm
@@ -448,8 +448,15 @@ sub _TicketCreate {
         || $Param->{GetParam}->{'X-KIX-SenderType'};
     $Param->{GetParam}->{'X-KIX-Channel'} = $Self->{Config}->{CreateChannel}
         || $Param->{GetParam}->{'X-KIX-Channel'};
-    $Param->{GetParam}->{'X-KIX-Queue'} = $Self->{Config}->{CreateTicketQueue}
-        || $Param->{GetParam}->{'X-KIX-Queue'};
+    if($Param->{GetParam}->{'X-KIX-Queue'}  ne ''){
+        $Kernel::OM->Get('Log')->Log(
+            Priority => 'debug',
+            Message  => "X-KIX-Queue is already set to " . $Param->{GetParam}->{'X-KIX-Queue'},
+        );
+    }else{
+        $Param->{GetParam}->{'X-KIX-Queue'} = $Self->{Config}->{CreateTicketQueue}
+            || $Param->{GetParam}->{'X-KIX-Queue'};
+    }        
     $Param->{GetParam}->{'X-KIX-State'} = $Self->{Config}->{CreateTicketState}
         || $Param->{GetParam}->{'X-KIX-State'};
     $Param->{GetParam}->{'X-KIX-Type'} = $Self->{Config}->{CreateTicketType}

--- a/Kernel/System/PostMaster/Filter/SystemMonitoringX.pm
+++ b/Kernel/System/PostMaster/Filter/SystemMonitoringX.pm
@@ -449,14 +449,23 @@ sub _TicketCreate {
     $Param->{GetParam}->{'X-KIX-Channel'} = $Self->{Config}->{CreateChannel}
         || $Param->{GetParam}->{'X-KIX-Channel'};
     if($Param->{GetParam}->{'X-KIX-Queue'}  ne ''){
-        $Kernel::OM->Get('Log')->Log(
-            Priority => 'debug',
-            Message  => "X-KIX-Queue is already set to " . $Param->{GetParam}->{'X-KIX-Queue'},
-        );
+        my $QueueObject = $Kernel::OM->Get('Kernel::System::Queue');
+        if( $QueueObject->NameExistsCheck( Name =>  $Param->{GetParam}->{'X-KIX-Queue'},)){
+            $Kernel::OM->Get('Log')->Log(
+                Priority => 'notice',
+                Message  => "X-KIX-Queue is already set to " . $Param->{GetParam}->{'X-KIX-Queue'},
+            );
+        }else{
+            $Kernel::OM->Get('Log')->Log(
+                Priority => 'notice',
+                Message  => "X-KIX-Queue set to " . $Param->{GetParam}->{'X-KIX-Queue'} . " but the Queue was not found, using standard " . $Self->{Config}->{CreateTicketQueue},
+            );
+            $Param->{GetParam}->{'X-KIX-Queue'} = $Self->{Config}->{CreateTicketQueue};
+        }
     }else{
         $Param->{GetParam}->{'X-KIX-Queue'} = $Self->{Config}->{CreateTicketQueue}
             || $Param->{GetParam}->{'X-KIX-Queue'};
-    }        
+    }    
     $Param->{GetParam}->{'X-KIX-State'} = $Self->{Config}->{CreateTicketState}
         || $Param->{GetParam}->{'X-KIX-State'};
     $Param->{GetParam}->{'X-KIX-Type'} = $Self->{Config}->{CreateTicketType}


### PR DESCRIPTION
If the Monitoring System sets the Mail Header X-KIX-Queue it should be used instead of the static config from Sysconfig